### PR TITLE
Abandon iframe approach and render markdown client-side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+index.html: template.html clm-manifesto.md index.js
+	node index.js

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # livable.github.io
+
+```sh
+npm install
+make
+```

--- a/clm-manifesto.md
+++ b/clm-manifesto.md
@@ -1,0 +1,57 @@
+# Announcing the Center for Livable Media
+
+Changes in cities can make them better or worse for the people who live in them. Like cities, media systems influence our lives and interactions. So, our media--the technologies of thought and communication available to us--can also be better or worse for us. Yet few researchers develop and design new media explicitly so as to work out better for people.
+
+The Center for Livable Media will find these researchers and support their work. There will be international research groups around certain topics. There will be a physical space in Berlin for residencies and for in-person media experiments. There will be support for building communities of practice around the projects that emerge.
+
+
+## Research Groups
+
+Our initial research groups will focus on two ideas. First, inventing media that give us greater agency in our lives. Second, inventing media that supports a more complete social fabric. These groups come from a dissatisfaction with how current media shape our lives.
+
+When we sense that we are making meaningful choices and acts, and deciding how our lives should go, that's called agency. Some environments encourage meaningful choices, while others funnel us along in a way that limits our agency. Current media does too much funneling.
+
+Each person needs certain relationships in order to live fully and well. We can use the term social fabric for the collection of all these relations and all of the activities they consist of. Current media does not support a full range of relationships and activities.
+
+These are lenses to look at how media impacts life. They are <a name="text">abstractions</a><sup>[0](#abstraction)</sup>, their use justified only by how they appear as common threads in real, human lives.
+
+
+
+## Research Groups—Agency
+
+**Choice.** When using notification screens, newsfeeds, and voice prompts, we make small and large choices about our lives, about our relationships, and about our time. But often these interactions are structured to take agency away from us, to keep us isolated and “engaging” with the device. Accordingly, CLM supports work on *interfaces for meaningful choice*. Our researchers will seek out design principles and interface paradigms that help the user to discover and pursue their truest desires, with the greatest agency, rather than sloshing down a designed funnel or operating according to habit.
+
+**Histories.** The time structure of audio, video, text, and infinitely scrolling feeds can put us in an unexpressive, unreflective, and dissociated state. This can create attitudes of passive consumption, both regarding our personal history, and our collective histories and destinies. Accordingly, CLM supports work on intimate and expressive *interfaces for confronting histories*, not just to "play" them or to scroll through them. Our researchers will develop algorithms, representations, and interfaces for working with recorded histories that provide agency to an individual over a mass of media.
+
+**Sanctuary.** Operating systems APIs and SDKs allow apps to tell us what's important--via notifications and feeds and other interactions--rather than ensuring apps respect how we want our lives to go. Accordingly, CLM supports developing *platform APIs for human dignity*. Our researchers will design alternate operating system API layers that provides sanctuary from third party manipulation, respecting and supporting people's lives and deepest values.
+
+
+## Research Groups—Social Fabric
+
+**Gift.** What are the most substantial ways for others to be in our lives? What social acts are transformative for us? What are the biggest gifts we give one another? Whether it’s helping someone move, sharing a passion, inviting them to feel their feelings, confronting a scary challenge together — these acts aren't enabled by current social networks, which restrict behavior. Accordingly, CLM supports prototyping *negotiable models for social networking that support transformative, substantial, relationships*.
+
+**Response.** Public actors--whether they are celebrities, companies, artists, governments, or nonprofits--have a huge impact on a network of people. They try to be responsible for that impact by using twitter @-replies, analytics dashboards, metrics, and feedback forms. These platforms do not surface the information required to be deeply responsible to someone. Accordingly, CLM supports work on *responsible networks*. But what does it take to be deeply responsible to someone? You may need analysis of their hopes, values, and situations that these platforms don't collect.
+
+**Desire.** We need many kinds of social relations to live well--clubs, mentorships, partnerships, social routines, etc. The requisite social activity should follow from the expression of social needs. Existing platforms like Meetup and Facebook Groups hardly support the statement of needs or adequate structures where they could be met. Often we end up choosing social relations that fit into an app or the prevailing culture. Accordingly, CLM supports work on *actionable specification of social needs*.
+
+
+## Work with us
+
+There will be many ways to participate!  We will be gathering researchers for these teams and raising funds to support them.
+
+We'll be launching a training program for those who can apply our research. We're looking for interested organization who can benefit from our research, and for groups that want to help us run the training.
+
+Please get in touch if you want to help.
+
+Yours,
+
+Rob Ochshorn and Joe Edelman  
+April 2016  
+BERLIN
+
+
+<sub><a name="abstraction">0</a>: Most idealists hope their work will improve human lives, but idealistic thinking can get dangerous as it moves away from the details of human life. There is a tendency to turn abstract ideas--ideas like “happiness,” “privacy,” “sharing,” "immersive," "distributed," "efficient," "compelling," or even "social"--into ends. Ideals become ideologies, and work done in their name becomes disconnected from human reality, and sometimes harmful.</sub>
+
+<sub>For this reason, CLM will support a certain kind of research. We'll avoid work which doesn't land in people lives in a practical, everyday, way: for instance, we'll avoid critical art, critical commentary, and awareness campaigns. We will also avoid anything with structural pressure to pretend to be beneficial: for example, we'll avoid consumer products and spin-off NGOs.</sub>
+
+<sub>Instead, CLM will support researchers who develop motivating proofs-of-concept and prototypes, loose methodologies, or simple communities of practice. CLM researchers will be vigilant and explicit about when abstract values become motivations, and will work to evaluate projects by the rich unexpected details of the diverse human lives where their prototypes find expression. [↩](#text) </sub>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,30 @@
-<style>
-body{ max-width: 600px; margin: 40px auto; }
-.gist .gist-file { border: none !important ; }
-</style>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Center for Livable Media</title>
+    <style>
+body {
+    max-width: 600px;
+    margin: 40px auto;
+    font-family: Helvetica, sans;
+    color: #333;
+    line-height: 1.6;
+}
+a {
+    color: black;
+    text-decoration: none;
+}
+a:hover {
+    color: #333;
+}
+h1 {
+    border-bottom: 1px solid #eee
+    line-height: 1.2;
+}
 
+    </style>
+  </head>
+  <body>
 <form style="padding:3px;text-align:center;" action="https://tinyletter.com/livablemedia" method="post" target="popupwindow" onsubmit="window.open('https://tinyletter.com/livablemedia', 'popupwindow', 'scrollbars=yes,width=800,height=600');return true">
   <p><input type="text" style="width:140px" name="email" id="tlemail"
     placeholder="Enter your email address" />
@@ -10,4 +32,34 @@ body{ max-width: 600px; margin: 40px auto; }
   <input type="submit" value="Stay in touch" /></p>
 </form>
 
-<script src="https://gist.github.com/jxe/694033bd36975a11a459.js"></script>
+<h1 id="user-content-announcing-the-center-for-livable-media" class="deep-link"><a href="#announcing-the-center-for-livable-media">Announcing the Center for Livable Media</a></h1>
+<p>Changes in cities can make them better or worse for the people who live in them. Like cities, media systems influence our lives and interactions. So, our media--the technologies of thought and communication available to us--can also be better or worse for us. Yet few researchers develop and design new media explicitly so as to work out better for people.</p>
+<p>The Center for Livable Media will find these researchers and support their work. There will be international research groups around certain topics. There will be a physical space in Berlin for residencies and for in-person media experiments. There will be support for building communities of practice around the projects that emerge.</p>
+<h2 id="user-content-research-groups" class="deep-link"><a href="#research-groups">Research Groups</a></h2>
+<p>Our initial research groups will focus on two ideas. First, inventing media that give us greater agency in our lives. Second, inventing media that supports a more complete social fabric. These groups come from a dissatisfaction with how current media shape our lives.</p>
+<p>When we sense that we are making meaningful choices and acts, and deciding how our lives should go, that&apos;s called agency. Some environments encourage meaningful choices, while others funnel us along in a way that limits our agency. Current media does too much funneling.</p>
+<p>Each person needs certain relationships in order to live fully and well. We can use the term social fabric for the collection of all these relations and all of the activities they consist of. Current media does not support a full range of relationships and activities.</p>
+<p>These are lenses to look at how media impacts life. They are <a name="text">abstractions</a><sup><a href="#abstraction">0</a></sup>, their use justified only by how they appear as common threads in real, human lives.</p>
+<h2 id="user-content-research-groupsagency" class="deep-link"><a href="#research-groupsagency">Research Groups&#x2014;Agency</a></h2>
+<p><strong>Choice.</strong> When using notification screens, newsfeeds, and voice prompts, we make small and large choices about our lives, about our relationships, and about our time. But often these interactions are structured to take agency away from us, to keep us isolated and &#x201C;engaging&#x201D; with the device. Accordingly, CLM supports work on <em>interfaces for meaningful choice</em>.&#xA0;Our researchers will seek out design principles and interface paradigms that help the user to discover and pursue their truest desires, with the greatest agency, rather than sloshing down a designed funnel or operating according to habit.</p>
+<p><strong>Histories.</strong> The time structure of audio, video, text, and infinitely scrolling feeds can put us in an unexpressive, unreflective, and dissociated state. This can create attitudes of passive consumption, both regarding our personal history, and our collective histories and destinies. Accordingly, CLM supports work on intimate and expressive <em>interfaces for confronting histories</em>, not just to &quot;play&quot; them or to scroll through them. Our researchers will develop algorithms, representations, and interfaces for working with recorded histories that provide agency to an individual over a mass of media.</p>
+<p><strong>Sanctuary.</strong> Operating systems APIs and SDKs allow apps to tell us what&apos;s important--via notifications and feeds and other interactions--rather than ensuring apps respect how we want our lives to go. Accordingly, CLM supports developing <em>platform APIs for human dignity</em>. Our researchers will design alternate operating system API layers that provides sanctuary from third party manipulation, respecting and supporting people&apos;s lives and deepest values.</p>
+<h2 id="user-content-research-groupssocial-fabric" class="deep-link"><a href="#research-groupssocial-fabric">Research Groups&#x2014;Social Fabric</a></h2>
+<p><strong>Gift.</strong> What are the most substantial ways for others to be in our lives? What social acts are transformative for us? What are the biggest gifts we give one another? Whether it&#x2019;s helping someone move, sharing a passion, inviting them to feel their feelings, confronting a scary challenge together&#x200A;&#x2014;&#x200A;these acts aren&apos;t enabled by current social networks, which restrict behavior. Accordingly, CLM supports prototyping <em>negotiable models for social networking that support transformative, substantial, relationships</em>.</p>
+<p><strong>Response.</strong> Public actors--whether they are celebrities, companies, artists, governments, or nonprofits--have a huge impact on a network of people. They try to be responsible for that impact by using twitter @-replies, analytics dashboards, metrics, and feedback forms. These platforms do not surface the information required to be deeply responsible to someone. Accordingly, CLM supports work on <em>responsible networks</em>. But what does it take to be deeply responsible to someone? You may need analysis of their hopes, values, and situations that these platforms don&apos;t collect.</p>
+<p><strong>Desire.</strong> We need many kinds of social relations to live well--clubs, mentorships, partnerships, social routines, etc. The requisite social activity should follow from the expression of social needs. Existing platforms like Meetup and Facebook Groups hardly support the statement of needs or adequate structures where they could be met. Often we end up choosing social relations that fit into an app or the prevailing culture. Accordingly, CLM supports work on <em>actionable specification of social needs</em>.</p>
+<h2 id="user-content-work-with-us" class="deep-link"><a href="#work-with-us">Work with us</a></h2>
+<p>There will be many ways to participate!  We will be gathering researchers for these teams and raising funds to support them.</p>
+<p>We&apos;ll be launching a training program for those who can apply our research. We&apos;re looking for interested organization who can benefit from our research, and for groups that want to help us run the training.</p>
+<p>Please get in touch if you want to help.</p>
+<p>Yours,</p>
+<p>Rob Ochshorn and Joe Edelman<br>
+April 2016<br>
+BERLIN</p>
+<p><sub><a name="abstraction">0</a>: Most idealists hope their work will improve human lives, but idealistic thinking can get dangerous as it moves away from the details of human life. There is a tendency to turn abstract ideas--ideas like &#x201C;happiness,&#x201D; &#x201C;privacy,&#x201D; &#x201C;sharing,&#x201D; &quot;immersive,&quot; &quot;distributed,&quot; &quot;efficient,&quot; &quot;compelling,&quot; or even &quot;social&quot;--into ends. Ideals become ideologies, and work done in their name becomes disconnected from human reality, and sometimes harmful.</sub></p>
+<p><sub>For this reason, CLM will support a certain kind of research. We&apos;ll avoid work which doesn&apos;t land in people lives in a practical, everyday, way: for instance, we&apos;ll avoid critical art, critical commentary, and awareness campaigns. We will also avoid anything with structural pressure to pretend to be beneficial: for example, we&apos;ll avoid consumer products and spin-off NGOs.</sub></p>
+<p><sub>Instead, CLM will support researchers who develop motivating proofs-of-concept and prototypes, loose methodologies, or simple communities of practice. CLM researchers will be vigilant and explicit about when abstract values become motivations, and will work to evaluate projects by the rich unexpected details of the diverse human lives where their prototypes find expression. <a href="#text">&#x21A9;</a> </sub></p>
+
+
+  </body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+// Creates 'index.html' by rendering "clm-manifesto.md" into "template.html"
+
+var fs = require("fs");
+var marky = require("marky-markdown");
+
+var templ = fs.readFileSync("template.html", encoding="utf-8");
+var manifesto = marky(fs.readFileSync("clm-manifesto.md", encoding="utf-8")).html();
+
+templ = templ.replace("{{manifesto}}", manifesto);
+
+fs.writeFileSync("index.html", templ, encoding="utf-8");

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "livable.github.io",
+  "dependencies": {
+    "marky-markdown": "^7.0.0"
+  }
+}

--- a/template.html
+++ b/template.html
@@ -1,0 +1,38 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Center for Livable Media</title>
+    <style>
+body {
+    max-width: 600px;
+    margin: 40px auto;
+    font-family: Helvetica, sans;
+    color: #333;
+    line-height: 1.6;
+}
+a {
+    color: black;
+    text-decoration: none;
+}
+a:hover {
+    color: #333;
+}
+h1 {
+    border-bottom: 1px solid #eee
+    line-height: 1.2;
+}
+
+    </style>
+  </head>
+  <body>
+<form style="padding:3px;text-align:center;" action="https://tinyletter.com/livablemedia" method="post" target="popupwindow" onsubmit="window.open('https://tinyletter.com/livablemedia', 'popupwindow', 'scrollbars=yes,width=800,height=600');return true">
+  <p><input type="text" style="width:140px" name="email" id="tlemail"
+    placeholder="Enter your email address" />
+  <input type="hidden" value="1" name="embed"/>
+  <input type="submit" value="Stay in touch" /></p>
+</form>
+
+{{manifesto}}
+
+  </body>
+</html>


### PR DESCRIPTION
Unfortunately, the gist embedding has too many limitations to be viable. For example, the relative links in the footnotes do not work. This commit moves the `clm-manifesto.md` document from a gist into this repository and provides a npm/Makefile-based process for updating `index.html`.
